### PR TITLE
Correct bug to save the best epoch model in modeling_gnn.py file

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ grea = GREAMolecularPredictor(
     num_task=num_task,
     task_type="regression",
     evaluate_higher_better=False,
-    verbose=True
+    verbose="progress_bar" #or "print_statement" recommended for jupyter notebooks, or "none"
 )
 
 # Fit with automatic hyperparameter tuning with 10 attempts, or implement .fit() with the default/manual hyperparameters

--- a/examples/generation/digress_on_qm9.py
+++ b/examples/generation/digress_on_qm9.py
@@ -5,7 +5,7 @@ from torch_molecule.datasets import load_qm9
 
 
 def train_on_qm9() -> None:
-    model = DigressMolecularGenerator(verbose=True, batch_size=1024, epochs=2)
+    model = DigressMolecularGenerator(verbose="progress_bar", batch_size=1024, epochs=2)
 
     smiles_list, _ = load_qm9(local_dir="torchmol_data")
 

--- a/examples/generation/graphdit_for_polymer.py
+++ b/examples/generation/graphdit_for_polymer.py
@@ -75,7 +75,7 @@ model_cond = GraphDITMolecularGenerator(
     task_type=['regression'] * len(property_names),
     batch_size=1024,
     drop_condition=0.1,
-    verbose=True,
+    verbose="progress_bar",
     # epochs=10000,
     epochs=10,
 )

--- a/examples/generation/graphga_for_polymer.py
+++ b/examples/generation/graphga_for_polymer.py
@@ -28,7 +28,7 @@ model_cond = GraphGAMolecularGenerator(
     offspring_size=10,
     n_jobs=1,
     iteration=5,
-    verbose=True
+    verbose="progress_bar"
 )
 print("GraphGA Model (conditional) initialized successfully")
 model_cond.fit(train_smiles_list, train_property_array)

--- a/examples/generation/graphga_with_tdc_oracle.py
+++ b/examples/generation/graphga_with_tdc_oracle.py
@@ -89,7 +89,7 @@ for idx, name in enumerate(oracle_names, 1):
         mutation_rate=0.01,
         n_jobs=10,
         iteration=10,
-        verbose=True
+        verbose="progress_bar"
     )
     
     # Fit the model

--- a/examples/prediction/plym_predict.py
+++ b/examples/prediction/plym_predict.py
@@ -99,7 +99,7 @@ def train_and_evaluate_models(model_type='both'):
             epochs=N_epoch,
             evaluate_criterion='r2',
             evaluate_higher_better=True,
-            verbose=True
+            verbose="progress_bar"
         )
         
         # Fit the model with hyperparameter optimization
@@ -153,7 +153,7 @@ def train_and_evaluate_models(model_type='both'):
             epochs=N_epoch,
             evaluate_criterion='r2',
             evaluate_higher_better=True,
-            verbose=True
+            verbose="progress_bar"
         )
         
         # Fit the model with hyperparameter optimization

--- a/tests/generator/defog.py
+++ b/tests/generator/defog.py
@@ -35,7 +35,7 @@ def test_defog_generator():
         learning_rate=5e-4,
         sample_steps=10,  # Fewer steps for faster testing
         guidance_weight=0.2,
-        verbose=True,
+        verbose="progress_bar",
     )
     print("Multi-Conditional DeFoG Model initialized successfully.")
     print(f"Input dim y: {conditional_model.input_dim_y}")
@@ -91,7 +91,7 @@ def test_defog_generator():
         learning_rate=5e-4,
         sample_steps=10,
         guidance_weight=0.2,
-        verbose=True,
+        verbose="progress_bar",
     )
     print("Single-Property Conditional DeFoG Model initialized successfully.")
     
@@ -112,7 +112,7 @@ def test_defog_generator():
         learning_rate=5e-4,
         sample_steps=10,  # Fewer steps for faster testing
         guidance_weight=0.0,  # No guidance for unconditional generation
-        verbose=True,
+        verbose="progress_bar",
     )
     print("Unconditional DeFoG Model initialized successfully.")
     print(f"Input dim y: {unconditional_model.input_dim_y}")

--- a/tests/generator/digress.py
+++ b/tests/generator/digress.py
@@ -29,7 +29,7 @@ def test_digress_generator():
         timesteps=500,
         batch_size=BATCH_SIZE,
         epochs=EPOCHS,
-        verbose=True,
+        verbose="progress_bar",
         lw_X=1,
         lw_E=5
     )

--- a/tests/generator/gdss.py
+++ b/tests/generator/gdss.py
@@ -29,7 +29,7 @@ def test_gdss_generator():
         batch_size=BATCH_SIZE,
         epochs=EPOCHS,
         learning_rate=0.005,
-        verbose=True
+        verbose="progress_bar"
     )
     print("GDSS Model initialized successfully")
 

--- a/tests/generator/graphdit.py
+++ b/tests/generator/graphdit.py
@@ -29,7 +29,7 @@ def test_graph_dit_generator():
         timesteps=500,
         batch_size=BATCH_SIZE,
         epochs=EPOCHS,
-        verbose=True,
+        verbose="progress_bar",
         guide_scale=2.0,
         lw_X=1,
         lw_E=5
@@ -81,7 +81,7 @@ def test_graph_dit_generator():
         timesteps=500,
         batch_size=BATCH_SIZE,
         epochs=EPOCHS,
-        verbose=True
+        verbose="progress_bar"
     )
     print("Unconditional GraphDIT Model initialized successfully")
 

--- a/tests/generator/graphga.py
+++ b/tests/generator/graphga.py
@@ -47,7 +47,7 @@ def test_graph_ga_generator():
         mutation_rate=0.01,
         n_jobs=1,  # Use 1 for easier debugging
         iteration=3,
-        verbose=True
+        verbose="progress_bar"
     )
     print("GraphGA Model (unconditional) initialized successfully")
     
@@ -59,7 +59,7 @@ def test_graph_ga_generator():
         mutation_rate=0.01,
         n_jobs=1,  # Use 1 for easier debugging
         iteration=3,
-        verbose=True
+        verbose="progress_bar"
     )
     print("GraphGA Model (conditional) initialized successfully")
     

--- a/tests/generator/jtvae.py
+++ b/tests/generator/jtvae.py
@@ -34,7 +34,7 @@ def test_jtvae_generator():
         depthG=2,         # Reduced for faster testing
         batch_size=BATCH_SIZE,
         epochs=EPOCHS,
-        verbose=True
+        verbose="progress_bar"
     )
     print("JTVAE Model initialized successfully")
 

--- a/tests/generator/lstm.py
+++ b/tests/generator/lstm.py
@@ -45,7 +45,7 @@ def test_lstm_generator():
         max_len=64,
         batch_size=BATCH_SIZE,
         epochs=EPOCHS,
-        verbose=True
+        verbose="progress_bar"
     )
     print("Unconditional LSTM Model initialized successfully")
 
@@ -89,7 +89,7 @@ def test_lstm_generator():
         num_task=len(property_columns),  # Set number of properties
         batch_size=BATCH_SIZE,
         epochs=EPOCHS,
-        verbose=True
+        verbose="progress_bar"
     )
     print("Property Conditional LSTM Model initialized successfully")
 

--- a/tests/generator/molgpt.py
+++ b/tests/generator/molgpt.py
@@ -39,7 +39,7 @@ def test_molgpt_generator():
         max_len=64,
         batch_size=BATCH_SIZE,
         epochs=EPOCHS,
-        verbose=True
+        verbose="progress_bar"
     )
     print("Unconditional MolGPT Model initialized successfully")
 
@@ -84,7 +84,7 @@ def test_molgpt_generator():
         num_task=1,  # Enable property conditioning
         batch_size=BATCH_SIZE,
         epochs=EPOCHS,
-        verbose=True
+        verbose="progress_bar"
     )
     print("Property Conditional MolGPT Model initialized successfully")
 
@@ -130,7 +130,7 @@ def test_molgpt_generator():
         use_scaffold=True,  # Enable scaffold conditioning
         batch_size=BATCH_SIZE,
         epochs=EPOCHS,
-        verbose=True
+        verbose="progress_bar"
     )
     print("Scaffold Conditional MolGPT Model initialized successfully")
 
@@ -177,7 +177,7 @@ def test_molgpt_generator():
         use_scaffold=True,  # Enable scaffold conditioning
         batch_size=BATCH_SIZE,
         epochs=EPOCHS,
-        verbose=True
+        verbose="progress_bar"
     )
     print("Combined Conditional MolGPT Model initialized successfully")
 

--- a/tests/predictor/bfgnn.py
+++ b/tests/predictor/bfgnn.py
@@ -23,7 +23,7 @@ def test_bfgnn_predictor():
         batch_size=4,
         epochs=100,  # Small number for testing
         patience=100,
-        verbose=True,
+        verbose="print_statement",
         l1_penalty=1e-3
     )
     print("Model initialized successfully")
@@ -68,9 +68,8 @@ def test_bfgnn_predictor():
     model_auto = BFGNNMolecularPredictor(
         num_task=1,
         task_type="classification",
-        epochs=3,  # Small number for testing
-        # verbose=True
-        verbose=False
+        epochs=50,  # Small number for testing
+        verbose="print_statement"
     )
     
     model_auto.autofit(

--- a/tests/predictor/dir.py
+++ b/tests/predictor/dir.py
@@ -24,7 +24,7 @@ def test_dir_predictor():
         hidden_size=128,
         batch_size=4,
         epochs=5,
-        verbose=True
+        verbose="progress_bar"
     )
     print("DIR model initialized successfully")
 
@@ -80,7 +80,7 @@ def test_dir_predictor():
         num_task=1,
         task_type="classification",
         epochs=3,
-        verbose=True
+        verbose="progress_bar"
     )
     
     model_auto.autofit(
@@ -103,7 +103,7 @@ def test_dir_predictor():
         num_task=1,
         task_type="classification",
         epochs=3,
-        verbose=True
+        verbose="progress_bar"
     )
     
     model_partial.autofit(
@@ -120,7 +120,7 @@ def test_dir_predictor():
         num_task=1,
         task_type="classification",
         epochs=3,
-        verbose=True
+        verbose="progress_bar"
     )
     
     model_default.autofit(
@@ -164,7 +164,7 @@ def test_dir_predictor():
         model_invalid = DIRMolecularPredictor(
             num_task=1,
             task_type="classification",
-            verbose=True
+            verbose="progress_bar"
         )
         model_invalid.autofit(
             smiles_list,
@@ -202,7 +202,7 @@ def test_dir_upload():
         hidden_size=64,   # Small embedding dimension
         batch_size=4,
         epochs=2,     # Few epochs for quick testing
-        verbose=False,
+        verbose="none",
         model_name='DIR_Invariant'
     )
     

--- a/tests/predictor/gnn.py
+++ b/tests/predictor/gnn.py
@@ -20,8 +20,8 @@ def test_gnn_predictor():
         num_layer=3,
         hidden_size=128,
         batch_size=4,
-        epochs=5,  # Small number for testing
-        verbose=True
+        epochs=20,  # Small number for testing
+        verbose="progress_bar"
     )
     print("Model initialized successfully")
 
@@ -61,8 +61,7 @@ def test_gnn_predictor():
         num_task=1,
         task_type="classification",
         epochs=3,  # Small number for testing
-        # verbose=True
-        verbose=False
+        verbose="none"
     )
     
     model_auto.autofit(

--- a/tests/predictor/grea.py
+++ b/tests/predictor/grea.py
@@ -25,7 +25,7 @@ def test_grea_predictor():
         hidden_size=128,
         batch_size=4,
         epochs=EPOCHS,
-        verbose=True
+        verbose="print_statement"
     )
     print("GREA model initialized successfully")
 
@@ -73,7 +73,7 @@ def test_grea_predictor():
         num_task=1,
         task_type="classification",
         epochs=EPOCHS,
-        verbose=True
+        verbose="print_statement"
     )
     
     model_auto.autofit(
@@ -97,7 +97,7 @@ def test_grea_predictor():
         num_task=1,
         task_type="classification",
         epochs=EPOCHS,
-        verbose=True
+        verbose="print_statement"
     )
     
     model_partial.autofit(
@@ -116,7 +116,7 @@ def test_grea_predictor():
         num_task=1,
         task_type="classification",
         epochs=EPOCHS,
-        verbose=True
+        verbose="print_statement"
     )
     
     model_default.autofit(
@@ -160,7 +160,7 @@ def test_grea_predictor():
         model_invalid = GREAMolecularPredictor(
             num_task=1,
             task_type="classification",
-            verbose=True
+            verbose="print_statement"
         )
         model_invalid.autofit(
             smiles_list,
@@ -203,7 +203,7 @@ def test_grea_upload():
         hidden_size=64,   # Small embedding dimension
         batch_size=4,
         epochs=EPOCHS,     # Few epochs for quick testing
-        verbose=False,
+        verbose="none",
         model_name='GREA_O2'
     )
     

--- a/tests/predictor/grin.py
+++ b/tests/predictor/grin.py
@@ -22,7 +22,7 @@ def test_grin_predictor():
         hidden_size=128,
         batch_size=4,
         epochs=5,  # Small number for testing
-        verbose=True,
+        verbose="progress_bar",
     )
     print("Model initialized successfully")
 
@@ -72,8 +72,7 @@ def test_grin_predictor():
         num_task=1,
         task_type="classification",
         epochs=3,  # Small number for testing
-        # verbose=True
-        verbose=False
+        verbose="none"
     )
     
     model_auto.autofit(

--- a/tests/predictor/irm.py
+++ b/tests/predictor/irm.py
@@ -113,7 +113,7 @@ def test_irm_gnn_predictor():
         batch_size=10,
         patience=1000,
         epochs=10,  # Small number for testing
-        verbose=True,
+        verbose="progress_bar", #or print_statement or none
         IRM_environment="random",  # IRM-specific
         penalty_weight=100,        # IRM-specific
         penalty_anneal_iters=2    # IRM-specific
@@ -159,7 +159,7 @@ def test_irm_gnn_predictor():
         num_task=1,
         task_type="classification",
         epochs=3,  # Small number for testing
-        verbose=False
+        verbose="progress_bar", #or print_statement or none
     )
     
     model_auto.autofit(

--- a/tests/predictor/lstm.py
+++ b/tests/predictor/lstm.py
@@ -30,7 +30,7 @@ def test_lstm_predictor():
         epochs=200,
         patience=200,
         device="cpu",
-        verbose=True
+        verbose="progress_bar"
     )
     print("Model initialized successfully")
 
@@ -58,7 +58,7 @@ def test_lstm_predictor():
         num_task=5,  # 5 tasks for multitask regression
         task_type="regression",
         epochs=3,  # Small number for testing
-        verbose=True
+        verbose="progress_bar"
     )
     
     model_auto.autofit(

--- a/tests/predictor/rpgnn.py
+++ b/tests/predictor/rpgnn.py
@@ -29,7 +29,7 @@ def train_rpgnn_predictor():
         hidden_size=300,
         batch_size=128,
         epochs=2,
-        verbose=True
+        verbose="progress_bar"
     )
     print("RPGNN model initialized successfully")   
     
@@ -68,7 +68,7 @@ def train_rpgnn_predictor():
         epochs=3,
         num_node_feature=num_node_feature,
         fixed_size=10,
-        verbose=True
+        verbose="progress_bar"
     )
     
     model_auto.autofit(

--- a/tests/predictor/sgir.py
+++ b/tests/predictor/sgir.py
@@ -27,7 +27,7 @@ def test_sgir_predictor():
         hidden_size=128,
         batch_size=4,
         epochs=20,
-        verbose=True,
+        verbose="progress_bar",
         warmup_epoch=5,
         labeling_interval=1,
         augmentation_interval=1
@@ -63,7 +63,7 @@ def test_sgir_predictor():
         num_task=1,
         task_type="regression",
         epochs=3,
-        verbose=True
+        verbose="progress_bar"
     )
     
     model_auto.autofit(

--- a/tests/predictor/smilestransformer.py
+++ b/tests/predictor/smilestransformer.py
@@ -29,7 +29,7 @@ def test_transformer_predictor():
         epochs=200,
         patience=200,
         device="cpu",
-        verbose=True,
+        verbose="progress_bar",
         use_lr_scheduler=True,
     )
     print("Model initialized successfully")
@@ -59,7 +59,7 @@ def test_transformer_predictor():
         num_task=1,
         task_type="regression",
         epochs=3,  # Small number for testing
-        verbose=True
+        verbose="progress_bar"
     )
     
     model_auto.autofit(
@@ -124,7 +124,7 @@ def test_transformer_predictor():
         batch_size=2,
         epochs=2,
         device="cpu",
-        verbose=True,
+        verbose="progress_bar",
         use_lr_scheduler=True,
     )
     print("Multitask model initialized successfully")
@@ -154,7 +154,7 @@ def test_transformer_predictor():
         num_task=5,  # 5 tasks for multitask regression
         task_type="regression",
         epochs=3,  # Small number for testing
-        verbose=True
+        verbose="progress_bar"
     )
     
     model_multitask_auto.autofit(

--- a/tests/predictor/ssr.py
+++ b/tests/predictor/ssr.py
@@ -31,7 +31,7 @@ def train_ssr_predictor():
         hidden_size=300,
         batch_size=128,
         epochs=EPOCHS,
-        verbose=True
+        verbose="progress_bar"
     )
     print("SSR model initialized successfully")   
     
@@ -68,7 +68,7 @@ def train_ssr_predictor():
         num_task=1,
         task_type="regression",
         epochs=3,
-        verbose=True
+        verbose="progress_bar"
     )
     
     model_auto.autofit(

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -113,7 +113,7 @@ def test_huggingface_interface():
         hidden_size=64,
         batch_size=4,
         epochs=2,
-        verbose=False,
+        verbose="none",
         model_name='GREA_TEST'
     )
     
@@ -253,7 +253,7 @@ def test_supervised_encoder_save_load():
     encoder = SupervisedMolecularEncoder(
         predefined_task=["morgan", "maccs"],
         epochs=2,
-        verbose=False
+        verbose="none"
     )
     
     try:

--- a/torch_molecule/encoder/attrmask/modeling_attrmask.py
+++ b/torch_molecule/encoder/attrmask/modeling_attrmask.py
@@ -106,7 +106,7 @@ class AttrMaskMolecularEncoder(BaseMolecularEncoder):
         self.use_lr_scheduler = use_lr_scheduler
         self.scheduler_factor = scheduler_factor
         self.scheduler_patience = scheduler_patience
-        self.verbose = verbose.lower()
+        self.verbose = verbose
         self.fitting_loss = list()
         self.fitting_epoch = 0
         self.model_class = GNN

--- a/torch_molecule/encoder/contextpred/modeling_contextpred.py
+++ b/torch_molecule/encoder/contextpred/modeling_contextpred.py
@@ -61,8 +61,8 @@ class ContextPredMolecularEncoder(BaseMolecularEncoder):
         Factor by which to reduce learning rate when plateau is reached.
     scheduler_patience : int, default=5
         Number of epochs with no improvement after which learning rate will be reduced.
-    verbose : bool, default=False
-        Whether to print progress information during training.
+    verbose : str, default="none"
+        Whether to display progress info. Options are: "none", "progress_bar", "print_statement". If any other, "none" is automatically chosen.
     device : Optional[Union[torch.device, str]], default=None
         Device to run the model on (CPU or GPU).
     model_name : str, default="ContextPredMolecularEncoder"
@@ -88,7 +88,7 @@ class ContextPredMolecularEncoder(BaseMolecularEncoder):
         use_lr_scheduler: bool = False,
         scheduler_factor: float = 0.5,
         scheduler_patience: int = 5,
-        verbose: bool = False,
+        verbose: str = "none",
         device: Optional[Union[torch.device, str]] = None,
         model_name: str = "ContextPredMolecularEncoder"
     ):
@@ -229,7 +229,9 @@ class ContextPredMolecularEncoder(BaseMolecularEncoder):
         total_steps = self.epochs * len(train_loader)
         
         # Initialize global progress bar
-        global_pbar = tqdm(total=total_steps, desc="Training Progress", disable=not self.verbose)
+        global_pbar = None
+        if self.verbose == "progress_bar":
+            global_pbar = tqdm(total=total_steps, desc="Training Progress")
 
         for epoch in range(self.epochs):
             # Training phase
@@ -237,8 +239,8 @@ class ContextPredMolecularEncoder(BaseMolecularEncoder):
             self.fitting_loss.append(np.mean(train_losses))
             if scheduler:
                 scheduler.step(np.mean(train_losses))
-
-        global_pbar.close()
+        if global_pbar is not None:
+            global_pbar.close()
         self.fitting_epoch = epoch
         self.is_fitted_ = True
         return self
@@ -269,13 +271,16 @@ class ContextPredMolecularEncoder(BaseMolecularEncoder):
             losses.append(loss.item())
 
             # Update global progress bar
-            if global_pbar is not None:
-                global_pbar.set_postfix({
+            log_dict = {
                     "Epoch": f"{epoch+1}/{self.epochs}",
                     "Step": f"{step+1}/{len(train_loader)}",
                     "Loss": f"{loss.item():.4f}"
-                })
+                }
+            if global_pbar is not None:
+                global_pbar.set_postfix(log_dict)
                 global_pbar.update(1)
+            if self.verbose == "print_statement":
+                print(log_dict)
 
         return losses
 

--- a/torch_molecule/encoder/edgepred/modeling_edgepred.py
+++ b/torch_molecule/encoder/edgepred/modeling_edgepred.py
@@ -97,7 +97,7 @@ class EdgePredMolecularEncoder(BaseMolecularEncoder):
         self.use_lr_scheduler = use_lr_scheduler
         self.scheduler_factor = scheduler_factor
         self.scheduler_patience = scheduler_patience
-        self.verbose = verbose.lower()
+        self.verbose = verbose
         self.fitting_loss = list()
         self.fitting_epoch = 0
         self.model_class = GNN

--- a/torch_molecule/encoder/edgepred/modeling_edgepred.py
+++ b/torch_molecule/encoder/edgepred/modeling_edgepred.py
@@ -54,8 +54,8 @@ class EdgePredMolecularEncoder(BaseMolecularEncoder):
         Factor by which to reduce learning rate when plateau is reached.
     scheduler_patience : int, default=5
         Number of epochs with no improvement after which learning rate will be reduced.
-    verbose : bool, default=False
-        Whether to print progress information during training.
+    verbose : str, default="none"
+        Whether to display progress info. Options are: "none", "progress_bar", "print_statement". If any other, "none" is automatically chosen.
     device : Optional[Union[torch.device, str]], default=None
         Device to run the model on (CPU or GPU).
     model_name : str, default="EdgePredMolecularEncoder"
@@ -78,7 +78,7 @@ class EdgePredMolecularEncoder(BaseMolecularEncoder):
         use_lr_scheduler: bool = False, 
         scheduler_factor: float = 0.5, 
         scheduler_patience: int = 5, 
-        verbose: bool = False, 
+        verbose: str = "none", 
         device: Optional[Union[torch.device, str]] = None,
         model_name: str = "EdgePredMolecularEncoder"
     ):
@@ -97,7 +97,7 @@ class EdgePredMolecularEncoder(BaseMolecularEncoder):
         self.use_lr_scheduler = use_lr_scheduler
         self.scheduler_factor = scheduler_factor
         self.scheduler_patience = scheduler_patience
-        self.verbose = verbose
+        self.verbose = verbose.lower()
         self.fitting_loss = list()
         self.fitting_epoch = 0
         self.model_class = GNN
@@ -212,7 +212,9 @@ class EdgePredMolecularEncoder(BaseMolecularEncoder):
         total_steps = self.epochs * len(train_loader)
         
         # Initialize global progress bar
-        global_pbar = tqdm(total=total_steps, desc="Training Progress", disable=not self.verbose)
+        global_pbar = None
+        if self.verbose == "progress_bar":
+            global_pbar = tqdm(total=total_steps, desc="Training Progress")
 
         for epoch in range(self.epochs):
             # Training phase
@@ -221,7 +223,8 @@ class EdgePredMolecularEncoder(BaseMolecularEncoder):
             if scheduler:
                 scheduler.step(np.mean(train_losses))
 
-        global_pbar.close()
+        if global_pbar is not None:
+            global_pbar.close()
         self.fitting_epoch = epoch
         self.is_fitted_ = True
         return self
@@ -252,13 +255,16 @@ class EdgePredMolecularEncoder(BaseMolecularEncoder):
             losses.append(loss.item())
 
             # Update global progress bar
-            if global_pbar is not None:
-                global_pbar.set_postfix({
+            log_dict = {
                     "Epoch": f"{epoch+1}/{self.epochs}",
                     "Step": f"{step+1}/{len(train_loader)}",
                     "Loss": f"{loss.item():.4f}"
-                })
+                }
+            if global_pbar is not None:
+                global_pbar.set_postfix(log_dict)
                 global_pbar.update(1)
+            if self.verbose == "print_statement":
+                print(log_dict)
 
         return losses
 

--- a/torch_molecule/encoder/graphmae/modeling_graphmae.py
+++ b/torch_molecule/encoder/graphmae/modeling_graphmae.py
@@ -124,7 +124,7 @@ class GraphMAEMolecularEncoder(BaseMolecularEncoder):
         self.use_lr_scheduler = use_lr_scheduler
         self.scheduler_factor = scheduler_factor
         self.scheduler_patience = scheduler_patience
-        self.verbose = verbose.lower()
+        self.verbose = verbose
         self.fitting_loss = list()
         self.fitting_epoch = 0
         self.model_class = GNN

--- a/torch_molecule/encoder/infograph/modeling_infograph.py
+++ b/torch_molecule/encoder/infograph/modeling_infograph.py
@@ -102,7 +102,7 @@ class InfoGraphMolecularEncoder(BaseMolecularEncoder):
         self.use_lr_scheduler = use_lr_scheduler
         self.scheduler_factor = scheduler_factor
         self.scheduler_patience = scheduler_patience
-        self.verbose = verbose.lower()
+        self.verbose = verbose
         self.fitting_loss = list()
         self.fitting_epoch = 0
         self.model_class = GNN

--- a/torch_molecule/encoder/moama/modeling_moama.py
+++ b/torch_molecule/encoder/moama/modeling_moama.py
@@ -106,7 +106,7 @@ class MoamaMolecularEncoder(BaseMolecularEncoder):
         self.use_lr_scheduler = use_lr_scheduler
         self.scheduler_factor = scheduler_factor
         self.scheduler_patience = scheduler_patience
-        self.verbose = verbose.lower()
+        self.verbose = verbose
         self.fitting_loss = list()
         self.fitting_epoch = 0
         self.model_class = GNN

--- a/torch_molecule/encoder/pretrained/modeling_pretrained.py
+++ b/torch_molecule/encoder/pretrained/modeling_pretrained.py
@@ -89,8 +89,8 @@ class HFPretrainedMolecularEncoder(BaseMolecularEncoder):
     add_bos_eos : Optional[bool], default=None
         Whether to add beginning/end of sequence tokens. If None, models in known_add_bos_eos_list will be set to True.
         The current known_add_bos_eos_list includes: ["entropy/gpt2_zinc_87m"].
-    verbose : bool, default=False
-        Whether to display progress information during encoding.
+    verbose : str, default="none"
+        Whether to display progress info. Options are: "none", "progress_bar", "print_statement". If any other, "none" is automatically chosen.
     device : Optional[Union[torch.device, str]], default=None
         Device to run the model on (CPU or GPU).
     model_name : str, default="HFPretrainedMolecularEncoder"
@@ -103,7 +103,7 @@ class HFPretrainedMolecularEncoder(BaseMolecularEncoder):
         max_length: int = 128, 
         batch_size: int = 128, 
         add_bos_eos: Optional[bool] = None,
-        verbose: bool = False,
+        verbose: str = "none",
         *,
         device: Optional[Union[torch.device, str]] = None,
         model_name: str = "HFPretrainedMolecularEncoder"
@@ -217,7 +217,10 @@ class HFPretrainedMolecularEncoder(BaseMolecularEncoder):
         
         # Process in batches
         all_embeddings = []
-        iterator = tqdm(range(0, len(X), self.batch_size), desc="Encoding molecules", total=len(X) // self.batch_size, disable=not self.verbose)
+        if self.verbose == "progress_bar" or self.verbose == "print_statement":
+            iterator = tqdm(range(0, len(X), self.batch_size), desc="Encoding molecules", total=len(X) // self.batch_size, disable=False)
+        else:
+            iterator = tqdm(range(0, len(X), self.batch_size), desc="Encoding molecules", total=len(X) // self.batch_size, disable=True)
         for i in iterator:
             batch_X = X[i:i + self.batch_size]
             

--- a/torch_molecule/encoder/supervised/modeling_supervised.py
+++ b/torch_molecule/encoder/supervised/modeling_supervised.py
@@ -99,7 +99,7 @@ class SupervisedMolecularEncoder(BaseMolecularEncoder):
         self.use_lr_scheduler = use_lr_scheduler
         self.scheduler_factor = scheduler_factor
         self.scheduler_patience = scheduler_patience
-        self.verbose = verbose.lower()
+        self.verbose = verbose
         self.fitting_loss = list()
         self.fitting_epoch = 0
         self.model_class = GNN

--- a/torch_molecule/generator/digress/modeling_digress.py
+++ b/torch_molecule/generator/digress/modeling_digress.py
@@ -108,7 +108,7 @@ class DigressMolecularGenerator(BaseMolecularGenerator):
         self.use_lr_scheduler = use_lr_scheduler
         self.scheduler_factor = scheduler_factor
         self.scheduler_patience = scheduler_patience
-        self.verbose = verbose.lower()
+        self.verbose = verbose
         self.fitting_loss = list()
         self.fitting_epoch = 0
         self.model_class = GraphTransformer

--- a/torch_molecule/generator/gdss/modeling_gdss.py
+++ b/torch_molecule/generator/gdss/modeling_gdss.py
@@ -163,7 +163,7 @@ class GDSSMolecularGenerator(BaseMolecularGenerator):
         self.sampler_n_steps = sampler_n_steps
         self.sampler_probability_flow = sampler_probability_flow
         self.sampler_noise_removal = sampler_noise_removal
-        self.verbose = verbose.lower()
+        self.verbose = verbose
         self.fitting_loss = list()
         self.fitting_epoch = 0
         self.model_class = GDSSModel

--- a/torch_molecule/generator/graph_dit/modeling_graph_dit.py
+++ b/torch_molecule/generator/graph_dit/modeling_graph_dit.py
@@ -122,7 +122,7 @@ class GraphDITMolecularGenerator(BaseMolecularGenerator):
         self.use_lr_scheduler = use_lr_scheduler
         self.scheduler_factor = scheduler_factor
         self.scheduler_patience = scheduler_patience
-        self.verbose = verbose.lower()
+        self.verbose = verbose
         self.fitting_loss = list()
         self.fitting_epoch = 0
         self.dataset_info = dict()

--- a/torch_molecule/generator/graph_ga/modeling_graph_ga.py
+++ b/torch_molecule/generator/graph_ga/modeling_graph_ga.py
@@ -37,8 +37,8 @@ class GraphGAMolecularGenerator(BaseMolecularGenerator):
         Number of parallel jobs to run. -1 means using all processors.
     iteration : int, default=5
         Number of iterations for each target label (or random sample) to run the genetic algorithm.
-    verbose : bool, default=False
-        Whether to display progress bars and logs.
+    verbose : str, default="none"
+        Whether to display progress info. Options are: "none", "progress_bar", "print_statement". If any other, "none" is automatically chosen.
     device : Optional[Union[torch.device, str]], default=None
         Device to run the model on (CPU or GPU).
     model_name : str, default="GraphGAMolecularGenerator"
@@ -52,7 +52,7 @@ class GraphGAMolecularGenerator(BaseMolecularGenerator):
         mutation_rate: float = 0.0067, 
         n_jobs: int = 1, 
         iteration: int = 5, 
-        verbose: bool = False, 
+        verbose: str = "none", 
         *,
         device: Optional[Union[torch.device, str]] = None,
         model_name: str = "GraphGAMolecularGenerator"
@@ -80,7 +80,7 @@ class GraphGAMolecularGenerator(BaseMolecularGenerator):
 
     def save_to_local(self, path: str):
         joblib.dump(self.oracle, path)
-        if self.verbose:
+        if self.verbose is not "none":
             print(f"Saved oracle to {path}")
 
     def load_from_local(self):
@@ -226,7 +226,7 @@ class GraphGAMolecularGenerator(BaseMolecularGenerator):
                 parallel_inputs.append((population_mol, label))
             
             # Run GA for all labels in parallel with tqdm progress bar
-            if self.verbose:
+            if self.verbose is not "none":
                 results = joblib.Parallel(n_jobs=self.n_jobs)(
                     delayed(self._run_generation)(pop_mol, lbl) 
                     for pop_mol, lbl in tqdm(parallel_inputs, desc="Generating molecules")
@@ -249,7 +249,7 @@ class GraphGAMolecularGenerator(BaseMolecularGenerator):
                 parallel_inputs.append((population_mol, None))
             
             # Run GA for all samples in parallel with tqdm progress bar
-            if self.verbose:
+            if self.verbose is not "none":
                 results = joblib.Parallel(n_jobs=self.n_jobs)(
                     delayed(self._run_generation)(pop_mol, lbl) 
                     for pop_mol, lbl in tqdm(parallel_inputs, desc="Generating molecules", total=num_samples)

--- a/torch_molecule/generator/lstm/modeling_lstm.py
+++ b/torch_molecule/generator/lstm/modeling_lstm.py
@@ -88,7 +88,7 @@ class LSTMMolecularGenerator(BaseMolecularGenerator):
         self.scheduler_factor = scheduler_factor
         self.scheduler_patience = scheduler_patience
         self.grad_norm_clip = grad_norm_clip
-        self.verbose = verbose.lower()
+        self.verbose = verbose
         self.fitting_loss = list()
         self.fitting_epoch = 0
         self.input_size = None

--- a/torch_molecule/generator/molgpt/modeling_molgpt.py
+++ b/torch_molecule/generator/molgpt/modeling_molgpt.py
@@ -101,7 +101,7 @@ class MolGPTMolecularGenerator(BaseMolecularGenerator):
         self.adamw_betas = adamw_betas
         self.weight_decay = weight_decay
         self.grad_norm_clip = grad_norm_clip
-        self.verbose = verbose.lower()
+        self.verbose = verbose
         self.fitting_loss = list()
         self.fitting_epoch = 0
         self.model_class = GPT

--- a/torch_molecule/predictor/bfgnn/modeling_bfgnn.py
+++ b/torch_molecule/predictor/bfgnn/modeling_bfgnn.py
@@ -126,7 +126,7 @@ class BFGNNMolecularPredictor(GNNMolecularPredictor):
             loss_criterion=loss_criterion,
             evaluate_criterion=evaluate_criterion,
             evaluate_higher_better=evaluate_higher_better,
-            verbose=verbose.lower(),
+            verbose=verbose,
             device=device,
             model_name=model_name,
         )

--- a/torch_molecule/predictor/bfgnn/modeling_bfgnn.py
+++ b/torch_molecule/predictor/bfgnn/modeling_bfgnn.py
@@ -65,8 +65,8 @@ class BFGNNMolecularPredictor(GNNMolecularPredictor):
         Factor by which to reduce learning rate when plateau is reached.
     scheduler_patience : int, default=5
         Number of epochs with no improvement after which learning rate will be reduced.
-    verbose : bool, default=False
-        Whether to print progress information during training.
+    verbose : str, default="none"
+        Whether to display progress info. Options are: "none", "progress_bar", "print_statement". If any other, "none" is automatically chosen.
     """
     
     def __init__(
@@ -100,7 +100,7 @@ class BFGNNMolecularPredictor(GNNMolecularPredictor):
         evaluate_criterion: Optional[Union[str, Callable]] = None,
         evaluate_higher_better: Optional[bool] = None,
         # General parameters
-        verbose: bool = False,
+        verbose: str = "none",
         device: Optional[torch.device | str] = None,
         model_name: str = "BFGNNMolecularPredictor",
     ):
@@ -126,7 +126,7 @@ class BFGNNMolecularPredictor(GNNMolecularPredictor):
             loss_criterion=loss_criterion,
             evaluate_criterion=evaluate_criterion,
             evaluate_higher_better=evaluate_higher_better,
-            verbose=verbose,
+            verbose=verbose.lower(),
             device=device,
             model_name=model_name,
         )

--- a/torch_molecule/predictor/dir/modeling_dir.py
+++ b/torch_molecule/predictor/dir/modeling_dir.py
@@ -144,7 +144,7 @@ class DIRMolecularPredictor(GNNMolecularPredictor):
             loss_criterion=loss_criterion,
             evaluate_criterion=evaluate_criterion,
             evaluate_higher_better=evaluate_higher_better,
-            verbose=verbose.lower(),
+            verbose=verbose,
             device=device,
             model_name=model_name,
         )

--- a/torch_molecule/predictor/dir/modeling_dir.py
+++ b/torch_molecule/predictor/dir/modeling_dir.py
@@ -79,8 +79,8 @@ class DIRMolecularPredictor(GNNMolecularPredictor):
         Metric for model evaluation.
     evaluate_higher_better : bool, optional
         Whether higher values of the evaluation metric are better.
-    verbose : bool, default=False
-        Whether to print progress information during training.
+    verbose : str, default="none"
+        Whether to display progress info. Options are: "none", "progress_bar", "print_statement". If any other, "none" is automatically chosen.
     device : torch.device or str, optional
         Device to use for computation.
     model_name : str, default="DIRMolecularPredictor"
@@ -118,7 +118,7 @@ class DIRMolecularPredictor(GNNMolecularPredictor):
         evaluate_criterion: Optional[Union[str, Callable]] = None,
         evaluate_higher_better: Optional[bool] = None,
         # General parameters
-        verbose: bool = False,
+        verbose: str = "none",
         device: Optional[Union[torch.device, str]] = None,
         model_name: str = "DIRMolecularPredictor",
     ):
@@ -144,7 +144,7 @@ class DIRMolecularPredictor(GNNMolecularPredictor):
             loss_criterion=loss_criterion,
             evaluate_criterion=evaluate_criterion,
             evaluate_higher_better=evaluate_higher_better,
-            verbose=verbose,
+            verbose=verbose.lower(),
             device=device,
             model_name=model_name,
         )

--- a/torch_molecule/predictor/gnn/modeling_gnn.py
+++ b/torch_molecule/predictor/gnn/modeling_gnn.py
@@ -168,7 +168,7 @@ class GNNMolecularPredictor(BaseMolecularPredictor):
         self.evaluate_higher_better = evaluate_higher_better
         
         # General parameters
-        self.verbose = verbose.lower()
+        self.verbose = verbose
         
         # Training state
         self.fitting_loss = list()

--- a/torch_molecule/predictor/grea/modeling_grea.py
+++ b/torch_molecule/predictor/grea/modeling_grea.py
@@ -110,7 +110,7 @@ class GREAMolecularPredictor(GNNMolecularPredictor):
         evaluate_criterion: Optional[Union[str, Callable]] = None,
         evaluate_higher_better: Optional[bool] = None,
         # General parameters
-        verbose: bool = False,
+        verbose: str = "none",
         device: Optional[Union[torch.device, str]] = None,
         model_name: str = "GREAMolecularPredictor",
     ):

--- a/torch_molecule/predictor/grin/modeling_grin.py
+++ b/torch_molecule/predictor/grin/modeling_grin.py
@@ -68,8 +68,8 @@ class GRINMolecularPredictor(GNNMolecularPredictor):
         Factor by which to reduce learning rate when plateau is reached.
     scheduler_patience : int, default=5
         Number of epochs with no improvement after which learning rate will be reduced.
-    verbose : bool, default=False
-        Whether to print progress information during training.
+    verbose : str, default="none"
+        Whether to display progress info. Options are: "none", "progress_bar", "print_statement". If any other, "none" is automatically chosen.
     device : torch.device or str, optional
         Device to use for computation.
     model_name : str, default="GRINMolecularPredictor"
@@ -133,7 +133,7 @@ class GRINMolecularPredictor(GNNMolecularPredictor):
             loss_criterion=loss_criterion,
             evaluate_criterion=evaluate_criterion,
             evaluate_higher_better=evaluate_higher_better,
-            verbose=verbose.lower(),
+            verbose=verbose,
             device=device,
             model_name=model_name,
         )

--- a/torch_molecule/predictor/grin/modeling_grin.py
+++ b/torch_molecule/predictor/grin/modeling_grin.py
@@ -107,7 +107,7 @@ class GRINMolecularPredictor(GNNMolecularPredictor):
         evaluate_criterion: Optional[Union[str, Callable]] = None,
         evaluate_higher_better: Optional[bool] = None,
         # General parameters
-        verbose: bool = False,
+        verbose: str = "none",
         device: Optional[Union[torch.device, str]] = None,
         model_name: str = "GRINMolecularPredictor"
     ):
@@ -133,7 +133,7 @@ class GRINMolecularPredictor(GNNMolecularPredictor):
             loss_criterion=loss_criterion,
             evaluate_criterion=evaluate_criterion,
             evaluate_higher_better=evaluate_higher_better,
-            verbose=verbose,
+            verbose=verbose.lower(),
             device=device,
             model_name=model_name,
         )

--- a/torch_molecule/predictor/irm/modeling_irm.py
+++ b/torch_molecule/predictor/irm/modeling_irm.py
@@ -78,8 +78,8 @@ class IRMMolecularPredictor(GNNMolecularPredictor):
         Factor by which to reduce learning rate when plateau is reached.
     scheduler_patience : int, default=5
         Number of epochs with no improvement after which learning rate will be reduced.
-    verbose : bool, default=False
-        Whether to print progress information during training.
+    verbose : str, default="none"
+        Whether to display progress info. Options are: "none", "progress_bar", "print_statement". If any other, "none" is automatically chosen.
     device : torch.device or str, optional
         Device to run the model on.
     """
@@ -117,7 +117,7 @@ class IRMMolecularPredictor(GNNMolecularPredictor):
         evaluate_criterion: Optional[Union[str, Callable]] = None,
         evaluate_higher_better: Optional[bool] = None,
         # General parameters
-        verbose: bool = False,
+        verbose: str = "none",
         device: Optional[Union[torch.device, str]] = None,
         model_name: str = "IRMMolecularPredictor",
     ):
@@ -143,7 +143,7 @@ class IRMMolecularPredictor(GNNMolecularPredictor):
             loss_criterion=loss_criterion,
             evaluate_criterion=evaluate_criterion,
             evaluate_higher_better=evaluate_higher_better,
-            verbose=verbose,
+            verbose=verbose.lower(),
             device=device,
             model_name=model_name
         )

--- a/torch_molecule/predictor/irm/modeling_irm.py
+++ b/torch_molecule/predictor/irm/modeling_irm.py
@@ -143,7 +143,7 @@ class IRMMolecularPredictor(GNNMolecularPredictor):
             loss_criterion=loss_criterion,
             evaluate_criterion=evaluate_criterion,
             evaluate_higher_better=evaluate_higher_better,
-            verbose=verbose.lower(),
+            verbose=verbose,
             device=device,
             model_name=model_name
         )

--- a/torch_molecule/predictor/lstm/modeling_lstm.py
+++ b/torch_molecule/predictor/lstm/modeling_lstm.py
@@ -125,7 +125,7 @@ class LSTMMolecularPredictor(BaseMolecularPredictor):
         self.use_lr_scheduler = use_lr_scheduler
         self.scheduler_factor = scheduler_factor
         self.scheduler_patience = scheduler_patience
-        self.verbose = verbose.lower()
+        self.verbose = verbose
         self.fitting_loss = list()
         self.fitting_epoch = 0
         self.model_class = LSTM

--- a/torch_molecule/predictor/rpgnn/modeling_rpgnn.py
+++ b/torch_molecule/predictor/rpgnn/modeling_rpgnn.py
@@ -72,8 +72,8 @@ class RPGNNMolecularPredictor(GNNMolecularPredictor):
         Factor by which to reduce learning rate when plateau is reached.
     scheduler_patience : int, default=5
         Number of epochs with no improvement after which learning rate will be reduced.
-    verbose : bool, default=False
-        Whether to print progress information during training.
+    verbose : str, default="none"
+        Whether to display progress info. Options are: "none", "progress_bar", "print_statement". If any other, "none" is automatically chosen.
     device : torch.device or str, optional
         Device to run the model on. If None, will auto-detect GPU or use CPU.
     model_name : str, default="RPGNNMolecularPredictor"
@@ -119,7 +119,7 @@ class RPGNNMolecularPredictor(GNNMolecularPredictor):
         evaluate_criterion: Optional[Union[str, Callable]] = None,
         evaluate_higher_better: Optional[bool] = None,
         # General parameters
-        verbose: bool = False,
+        verbose: str = "none",
         device: Optional[Union[torch.device, str]] = None,
         model_name: str = "RPGNNMolecularPredictor",
     ):

--- a/torch_molecule/predictor/sgir/modeling_sgir.py
+++ b/torch_molecule/predictor/sgir/modeling_sgir.py
@@ -161,7 +161,7 @@ class SGIRMolecularPredictor(GREAMolecularPredictor):
             loss_criterion=loss_criterion,
             evaluate_criterion=evaluate_criterion,
             evaluate_higher_better=evaluate_higher_better,
-            verbose=verbose.lower(),
+            verbose=verbose,
             device=device,
             model_name=model_name,
         )

--- a/torch_molecule/predictor/smiles_transformer/modeling_transformer.py
+++ b/torch_molecule/predictor/smiles_transformer/modeling_transformer.py
@@ -78,8 +78,8 @@ class SMILESTransformerMolecularPredictor(LSTMMolecularPredictor):
         Factor by which to reduce learning rate when plateau is reached.
     scheduler_patience : int, default=5
         Number of epochs with no improvement after which learning rate will be reduced.
-    verbose : bool, default=False
-        Whether to print progress information during training.
+    verbose : str, default="none"
+        Whether to display progress info. Options are: "none", "progress_bar", "print_statement". If any other, "none" is automatically chosen.
     """
     def __init__(
         self,
@@ -104,7 +104,7 @@ class SMILESTransformerMolecularPredictor(LSTMMolecularPredictor):
         use_lr_scheduler: bool = True,
         scheduler_factor: float = 0.5,
         scheduler_patience: int = 5,
-        verbose: bool = False,
+        verbose: str = "none",
         device: Optional[Union[torch.device, str]] = None,
         model_name: str = "SMILESTransformerMolecularPredictor",
     ):

--- a/torch_molecule/predictor/ssr/modeling_ssr.py
+++ b/torch_molecule/predictor/ssr/modeling_ssr.py
@@ -148,7 +148,7 @@ class SSRMolecularPredictor(GNNMolecularPredictor):
             loss_criterion=loss_criterion,
             evaluate_criterion=evaluate_criterion,
             evaluate_higher_better=evaluate_higher_better,
-            verbose=verbose.lower(),
+            verbose=verbose,
             device=device,
             model_name=model_name,
         )

--- a/torch_molecule/predictor/ssr/modeling_ssr.py
+++ b/torch_molecule/predictor/ssr/modeling_ssr.py
@@ -80,8 +80,8 @@ class SSRMolecularPredictor(GNNMolecularPredictor):
         Factor by which to reduce learning rate when plateau is reached.
     scheduler_patience : int, default=5
         Number of epochs with no improvement after which learning rate will be reduced.
-    verbose : bool, default=False
-        Whether to print progress information during training.
+    verbose : str, default="none"
+        Whether to display progress info. Options are: "none", "progress_bar", "print_statement". If any other, "none" is automatically chosen.
     device : torch.device or str, optional
         Device to use for computations.
     model_name : str, default="SSRMolecularPredictor"
@@ -122,7 +122,7 @@ class SSRMolecularPredictor(GNNMolecularPredictor):
         evaluate_criterion: Optional[Union[str, Callable]] = None,
         evaluate_higher_better: Optional[bool] = None,
         # General parameters
-        verbose: bool = False,
+        verbose: str = "none",
         device: Optional[Union[torch.device, str]] = None,
         model_name: str = "SSRMolecularPredictor",
     ):
@@ -148,7 +148,7 @@ class SSRMolecularPredictor(GNNMolecularPredictor):
             loss_criterion=loss_criterion,
             evaluate_criterion=evaluate_criterion,
             evaluate_higher_better=evaluate_higher_better,
-            verbose=verbose,
+            verbose=verbose.lower(),
             device=device,
             model_name=model_name,
         )


### PR DESCRIPTION
Hi. I found an important bug when making use of your code for the polymers competition. The bug is in the modeling_gnn python file which is parent of a lot of predictor models, (although changing just this file doesn't resolve the bug for the others). To avoid changing a lot of python files, I have decided to just show you the problem with the modiling_gnn.py file inside the GNN predictor folder first; and ask for your opinion before correcting the whole repo.  The issue is that during training, the model is saving the last epoch model_dict instead of best_model dict, although the code logic seems right at first glance. The problem is easy to fix by adding just 2 lines of code:
```
import copy
...
best_state_dict = copy.deepcopy(self.model.state_dict())
```

Instead of:
`best_state_dict = self.model.state_dict()`

Below are some links to references about why you need copy or deep copy to avoid this bug. Deep copy seems to work well in this case:

- https://stackoverflow.com/questions/61531864/why-do-we-need-state-dict-state-dict-copy
- https://www.binarystudy.com/2022/11/how-to-deepcopy-model-in-pytorch.html

Also I have made another change that require your opinion. Is about getting rid of progress bars and just make use of print statements after each epoch ends. I think this is more clear, specially if you are working in Jupyter notebooks and a small dataset. The original code that you've provided prints multiple training bar statements per second making impossible to compare errors between epochs and probably being a reason why the previous bug I have mention emerge. I will show you some photos to make the bug and the bars problem more clear:

Progress bars makes difficult to compare errors across epochs which is problematic and may cause bugs:
<img width="891" height="808" alt="Progress bars make difficult to see the best epoch mae" src="https://github.com/user-attachments/assets/46e7ac50-84f6-45ca-944a-e9ba3be6ef61" />

I replace them by print statements which clearly shows the bug. In the picture below I am showing the terminal output for a training loop of 40 epochs and a single optuna trial.
<img width="597" height="788" alt="Bug explained" src="https://github.com/user-attachments/assets/634f8c0b-76be-404a-a1cb-44b7c5b740c5" />

And below I am showing the new output with my correction, the bug is fixed!
<img width="578" height="789" alt="Bug fixed!" src="https://github.com/user-attachments/assets/64f7a71c-e463-4f2b-9dd8-196f33fa6c66" />
